### PR TITLE
Fix old style function definitions

### DIFF
--- a/drivers/soc/oppo/oppo_wakelock_profiler/oplus_wakelock_profiler_mtk.c
+++ b/drivers/soc/oppo/oppo_wakelock_profiler/oplus_wakelock_profiler_mtk.c
@@ -275,7 +275,7 @@ static struct pmic_irq_count_desc_t pmic_irq_info = {
 	.ws_number = 82,
 };
 
-void pmic_irq_count_function_init()
+void pmic_irq_count_function_init(void)
 {
 	int i = 0;
 
@@ -1001,7 +1001,7 @@ static void dump_rpmh_state()
 	PR_INFO("--->Screen_off_time=%lld(s)\n", screen_off_time);
 }
 
-void oplus_rpm_stats_statics_clear()
+void oplus_rpm_stats_statics_clear(void)
 {
 	int i, len;
 	struct rpmh_state_desc_t *desc;

--- a/drivers/soc/oppo/oppo_wakelock_profiler/oplus_wakelock_profiler_mtk.h
+++ b/drivers/soc/oppo/oppo_wakelock_profiler/oplus_wakelock_profiler_mtk.h
@@ -241,6 +241,8 @@ static const char *pmic_irq_name[82]={
 /* not wakeup source irq name, just used for statics*/
 #define IRQ_PROP_DUMMY_STATICS (1<<2)
 
+void pmic_irq_count_function_init(void);
+
 #if defined(CONFIG_OPPO_WAKELOCK_PROFILER) || defined(CONFIG_OPLUS_WAKELOCK_PROFILER)
 
 int wakeup_reasons_statics(const char *irq_name, u64 choose_flag);
@@ -248,8 +250,7 @@ void wakeup_reasons_clear(u64 choose_flag);
 void wakeup_reasons_print(u64 choose_flag, bool detail);
 struct timespec64 print_utc_time(char *annotation);
 void oplus_rpmh_stats_statics(const char *rpm_name,u64 sleep_count,u64 sleep_time);
-
-
+void oplus_rpm_stats_statics_clear(void);
 
 void alarmtimer_suspend_flag_set(void);
 void alarmtimer_suspend_flag_clear(void);


### PR DESCRIPTION
Adds void as a parameter to functions
 * oplus_rpm_stats_statics_clear,
 * pmic_irq_count_function_init